### PR TITLE
Fix Docker build broken by setuptools drift; parameterize CUDA arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# Editor / IDE settings
+.vscode/
+
 # mkdocs documentation
 /site
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,17 @@ RUN pip install torch==2.6.0 --index-url https://download.pytorch.org/whl/cu126
 # Copy source code (Docker context must be project root)
 COPY . .
 
-# Install unires package and its dependencies
-RUN pip install --upgrade pip setuptools wheel cython
+# Install unires package and its dependencies.
+# Pin build tools: nitorch's pinned commit calls the old positional distutils
+# compiler signature Compiler(None, dry_run, force), which setuptools 81 removed
+# when it reorganised the distutils compiler classes. Keep setuptools < 75 and
+# cython < 3 to stay in the working window (was unpinned; broke via setuptools drift).
+RUN pip install --upgrade pip && pip install "setuptools>=74,<75" wheel "cython<3.0"
 RUN pip install numpy==1.26.0
-ENV TORCH_CUDA_ARCH_LIST="8.9"
+# CUDA compute capability to compile nitorch kernels for; override to match your
+# GPU, e.g. docker build --build-arg TORCH_CUDA_ARCH_LIST=8.0 (A100). Find yours
+# with: nvidia-smi --query-gpu=compute_cap --format=csv
+ARG TORCH_CUDA_ARCH_LIST="8.9"
+ENV TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}
 ENV NI_COMPILED_BACKEND=C
 RUN pip install --no-build-isolation .

--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ docker build --rm --tag unires:latest .
 ```
 The build will use the compiled backend of `nitorch`, meaning it can take quite some time for the build to complete.
 
-If you get an error that the host GPU and its driver are not available, make sure that the environment variable `TORCH_CUDA_ARCH_LIST` in the `Dockerfile` includes a [CUDA compute capability](https://developer.nvidia.com/cuda-gpus) supported by your GPU. You can see the compute capability of your GPU with:
+If you get an error that the host GPU and its driver are not available, make sure the `TORCH_CUDA_ARCH_LIST` build argument matches a [CUDA compute capability](https://developer.nvidia.com/cuda-gpus) supported by your GPU. It defaults to `8.9`; override it at build time, e.g. for an A100 (compute capability 8.0):
+``` shell
+docker build --rm --build-arg TORCH_CUDA_ARCH_LIST=8.0 --tag unires:latest .
+```
+You can see the compute capability of your GPU with:
 ```sh
  nvidia-smi --query-gpu=compute_cap --format=csv
 ```


### PR DESCRIPTION
## Summary

Fresh `docker build` runs were failing while building `nitorch`. The root cause is **dependency drift, not a code change** — the Dockerfile's build-tools line was unpinned:

```dockerfile
RUN pip install --upgrade pip setuptools wheel cython
```

so builds now pull **setuptools 81+**, which reorganised the distutils compiler classes (`distutils.compilers.C.unix.Compiler`) and removed the old positional `Compiler(None, dry_run, force)` signature that nitorch's pinned commit calls. The Dockerfile built fine when authored (July 2025, setuptools 80.x); it rotted afterward.

Verified the boundary empirically:

| setuptools | old positional signature |
|---|---|
| 74.1.3 → 80.9.0 | ✅ works |
| 81.0.0 → 83.0.0 (latest) | ❌ broken |

## Changes

- **Pin build tools** to `setuptools>=74,<75` and `cython<3.0` to stay in the working window. (The `>=74` lower bound matters — Ubuntu's system setuptools 59.6 would otherwise satisfy a bare `<75` and get left in place.)
- **Parameterize `TORCH_CUDA_ARCH_LIST`** as a build arg (default `8.9`) so the image can target other GPUs without editing the Dockerfile, e.g. `--build-arg TORCH_CUDA_ARCH_LIST=8.0` for A100. Documented in the README.
- **Gitignore `.vscode/`.**

## Verification

- Full image builds cleanly with the pin.
- Build-arg override confirmed: `--build-arg TORCH_CUDA_ARCH_LIST=7.5` → image env `TORCH_CUDA_ARCH_LIST=7.5`.
- Algorithm runs end-to-end on GPU (RTX 1000 Ada): converged in 94 iterations / ~182 s, produced `u_*.nii.gz` outputs for the sample BrainWeb T1/T2/PD data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)